### PR TITLE
cookie fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "float",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "An SDK for interacting with Float.",
   "homepage": "https://github.com/hellofloat/float-sdk",
   "repository": {

--- a/src/cards.js
+++ b/src/cards.js
@@ -57,6 +57,7 @@ Cards.createCard = function( cb ) {
 
     superagent
         .post( 'https://' + self.options.host + '/card' )
+        .withCredentials()
         .send( {} )
         .end( function( error, response ) {
             if ( error ) {
@@ -112,6 +113,7 @@ Cards.getCard = function( cb ) {
 
     superagent
         .get( 'https://' + self.options.host + '/card' )
+        .withCredentials()
         .end( function( error, response ) {
             if ( error ) {
                 cb( response && response.body ? response.body : error );

--- a/src/passwords.js
+++ b/src/passwords.js
@@ -57,6 +57,7 @@ Passwords.requestReset = function( options, callback ) {
 
     superagent
         .post( 'https://' + self.options.host + '/password_reset_request' )
+        .withCredentials()
         .send( options )
         .end( function( error, response ) {
             if ( error ) {
@@ -146,6 +147,7 @@ Passwords.reset = function( options, callback ) {
 
     superagent
         .post( 'https://' + self.options.host + '/password_reset' )
+        .withCredentials()
         .send( options )
         .end( function( error, response ) {
             if ( error ) {

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -60,6 +60,7 @@ Scoring.addBank = function( overlay, cb ) {
 
     superagent
         .post( 'https://' + self.options.host + '/source/bankaccount' )
+        .withCredentials()
         .send( overlay )
         .end( function( error, response ) {
             if ( error ) {
@@ -117,6 +118,7 @@ Scoring.getBankAccount = function( cb ) {
 
     superagent
         .get( 'https://' + self.options.host + '/accounts' )
+        .withCredentials()
         .end( function( error, response ) {
             if ( error ) {
                 cb( response && response.body ? response.body : error );
@@ -190,6 +192,7 @@ Scoring.getScore = function( cb ) {
 
     superagent
         .get( 'https://' + self.options.host + '/score' )
+        .withCredentials()
         .end( function( error, response ) {
             if ( error ) {
                 cb( response && response.body ? response.body : error );

--- a/src/users.js
+++ b/src/users.js
@@ -113,6 +113,7 @@ Users.get = function( id, callback ) {
 
     superagent
         .get( 'https://' + self.options.host + '/user' + ( options.id ? '/' + options.id : '' ) )
+        .withCredentials()
         .end( function( error, response ) {
             if ( error && error.status !== 400 ) {
                 callback( response && response.body ? response.body : error );
@@ -227,6 +228,7 @@ Users.create = function( overlay, callback ) {
 
     superagent
         .post( 'https://' + self.options.host + '/user' )
+        .withCredentials()
         .send( overlay )
         .end( function( error, response ) {
             if ( error ) {
@@ -328,6 +330,7 @@ Users.update = function( user, overlay, callback ) {
 
     superagent
         .put( 'https://' + self.options.host + '/user/' + user.id )
+        .withCredentials()
         .send( overlay )
         .end( function( error, response ) {
             if ( error ) {
@@ -382,6 +385,7 @@ Users.del = function( user, callback ) {
 
     superagent
         .del( 'https://' + self.options.host + '/user/' + user.id )
+        .withCredentials()
         .end( function( error, response ) {
             if ( error ) {
                 callback( response && response.body ? response.body : error );
@@ -467,6 +471,7 @@ Users.login = function( data, callback ) {
 
     superagent
         .post( 'https://' + self.options.host + '/login' )
+        .withCredentials()
         .send( data )
         .end( function( error, response ) {
             if ( error ) {
@@ -526,6 +531,7 @@ Users.logout = function( callback ) {
 
     superagent
         .post( 'https://' + self.options.host + '/logout' )
+        .withCredentials()
         .end( function( error, response ) {
             if ( error ) {
                 callback( response && response.body ? response.body : error );


### PR DESCRIPTION
withCredentials() options needs to be added to any superagent call making a CORS request.
It allows for cookies to be passed to and from the servers.
